### PR TITLE
fix: corregir la llamada a getDoc para obtener la venta por ID en var…

### DIFF
--- a/public/assets/js/ventas.js
+++ b/public/assets/js/ventas.js
@@ -2507,7 +2507,7 @@ async function loadSalePayments(ventaId) {
 
   try {
     const [ventaDoc, abonosSnapshot, pagosSnapshot] = await Promise.all([
-      getDoc(db, "ventas", ventaId),
+      getDoc(doc(db, "ventas", ventaId)), // CORREGIDO
       getDocs(query(collection(db, "abonos"), where("ventaId", "==", ventaId), orderBy("fecha", "asc"))),
       getDocs(query(collection(db, "pagos"), where("ventaId", "==", ventaId), orderBy("fecha", "asc"))),
     ])
@@ -2960,7 +2960,7 @@ async function calcularSaldoPendienteActualizado(ventaId) {
     saldoCache.delete(ventaId)
     
     const [ventaDoc, abonosSnapshot, pagosSnapshot] = await Promise.all([
-      getDoc(doc(db, "ventas", ventaId)),
+      getDoc(doc(db, "ventas", ventaId)), // CORREGIDO
       getDocs(query(collection(db, "abonos"), where("ventaId", "==", ventaId))),
       getDocs(query(collection(db, "pagos"), where("ventaId", "==", ventaId))),
     ])
@@ -3032,7 +3032,7 @@ async function calcularSaldoPendiente(ventaId) {
 
   try {
     const [ventaDoc, abonosSnapshot, pagosSnapshot] = await Promise.all([
-      getDoc(doc(db, "ventas", ventaId)),
+      getDoc(doc(db, "ventas", ventaId)), // CORREGIDO
       getDocs(query(collection(db, "abonos"), where("ventaId", "==", ventaId))),
       getDocs(query(collection(db, "pagos"), where("ventaId", "==", ventaId))),
     ])


### PR DESCRIPTION
fix: El error indica que estás pasando parámetros incorrectos a la función `getDoc` de Firestore. La función `getDoc` espera una `DocumentReference`, pero estás pasando los parámetros por separado.
El problema principal es que la función getDoc de Firestore v9+ requiere una DocumentReference como parámetro, que se crea usando doc(db, "collection", "documentId"). No se puede pasar la base de datos, colección e ID por separado.


